### PR TITLE
Fix for IE9

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const _ = require('lodash');
-const toString = Object.prototype.toString;
+var _ = require('lodash');
+var toString = Object.prototype.toString;
 
 function type(val) {
   return toString.call(val).toLowerCase().replace(/\[object ([\S]+)\]/, '$1');


### PR DESCRIPTION
Replace "const" with "var" so IE9 does not break when this script is read as part of some bundle.

Could you please consider this? I know the rest of the script might not be compatible with IE 9 anyway, but at least this change allows bundling expand-hash (the functionality requiring expand-hash could be hidden from IE  9, for example).